### PR TITLE
Use openjdk:8u111-jdk As Base Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8u72-jdk
+FROM openjdk:8u111-jdk
 MAINTAINER James McClain <james.mcclain@gmail.com>
 
 ADD hadoop-2.7.2.tar.gz /opt

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all: hadoop-2.7.2.tar.gz
-	docker build -t hadoop:1 .
+	docker build -t jamesmcclain/hadoop:8u111 .
 
 hadoop-2.7.2.tar.gz:
 	curl -C - -O 'http://mirror.stjschools.org/public/apache/hadoop/common/hadoop-2.7.2/hadoop-2.7.2.tar.gz'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ by pulling it from Docker Hub or building it using the provided Makefile.
 To pull the image from Docker Hub, type:
 
 ```bash
-docker pull jamesmcclain/hadoop:1
+docker pull jamesmcclain/hadoop:8u111
 ```
 
 ### Building ###
@@ -28,7 +28,8 @@ The leader contains a YARN Resource Manager, a Hadoop NameNode, a MapReduce Hist
 To run the leader, type:
 
 ```bash
-docker run -it --rm -p 8088:8088 -p 50070:50070 -p 19888:19888 -h leader --name leader --entrypoint /scripts/leader.sh jamesmcclain/hadoop:1
+docker network create --driver bridge geowave
+docker run -it --rm --net=geowave -p 8088:8088 -p 50070:50070 -p 19888:19888 --hostname leader --name leader --entrypoint /scripts/leader.sh jamesmcclain/hadoop:8u111
 ```
 
 ## Running a Follower ###
@@ -37,5 +38,5 @@ A follower contains a YARN NodeManager and a Hadoop DataNode.
 To run a follower, type:
 
 ```bash
-docker run -it --rm --link leader --entrypoint /scripts/follower.sh jamesmcclain/hadoop:1
+docker run -it --rm --net=geowave --hostname follower1 --name follower1 --entrypoint /scripts/follower.sh jamesmcclain/hadoop:8u111
 ```


### PR DESCRIPTION
The `openjdk:8u111` image is now used as the base image instead of `java:openjdk-8u72-jdk`.